### PR TITLE
Fix ref pointer prefix for Open Api docs

### DIFF
--- a/packages/core/src/backend.ts
+++ b/packages/core/src/backend.ts
@@ -63,7 +63,7 @@ export class Backend {
             // tslint:disable-next-line:no-any
             const metadatas = (getFromContainer(MetadataStorage) as any).validationMetadatas;
             const schemas = validationMetadatasToSchemas(metadatas, {
-                refPointerPrefix: '#/components/schemas',
+                refPointerPrefix: '#/components/schemas/',
             });
 
 


### PR DESCRIPTION
The missing slash leads to incorrectly generated ref pointers for nested objects.