### PR TITLE
fix: removing entity from db must be done after removing from filesystem

### DIFF
--- a/packages/media-management/src/providers/file-upload.provider.ts
+++ b/packages/media-management/src/providers/file-upload.provider.ts
@@ -166,7 +166,7 @@ export class FileUploadProvider {
                         hash: file.hash,
                     },
                 });
-                
+
                 if (fileEntity instanceof FileEntity) {
                     await this.fileStorageProvider.deleteFile(file.hash);
                 }

--- a/packages/media-management/src/providers/file-upload.provider.ts
+++ b/packages/media-management/src/providers/file-upload.provider.ts
@@ -161,16 +161,17 @@ export class FileUploadProvider {
         }
         try {
             for (const file of medium.files) {
-                await entityManager.remove(file);
-
                 const fileEntity = await entityManager.findOne(FileEntity, {
                     where: {
                         hash: file.hash,
                     },
                 });
+                
                 if (fileEntity instanceof FileEntity) {
                     await this.fileStorageProvider.deleteFile(file.hash);
                 }
+
+                await entityManager.remove(file);
             }
 
             await entityManager.remove(medium);


### PR DESCRIPTION
the FileEntity was removed from the db before deleting it from the filesystem, causing zombie files in the storage